### PR TITLE
fix(clientid): fix some ip-related bugs

### DIFF
--- a/src/Protocols/NFS/nfs4_op_exchange_id.c
+++ b/src/Protocols/NFS/nfs4_op_exchange_id.c
@@ -40,7 +40,7 @@
 #include "sal_functions.h"
 #include "nfs_creds.h"
 
-int get_raddr(SVCXPRT *xprt)
+uint32_t get_raddr(SVCXPRT *xprt)
 {
 	sockaddr_t *ss = svc_getrpclocal(xprt);
 	int addr = 0;

--- a/src/Protocols/NFS/nfs4_op_setclientid.c
+++ b/src/Protocols/NFS/nfs4_op_setclientid.c
@@ -82,6 +82,7 @@ enum nfs_req_result nfs4_op_setclientid(struct nfs_argop4 *op,
 	nfs_client_id_t *unconf;
 	clientid4 clientid;
 	verifier4 verifier;
+	uint32_t server_addr;
 	int rc;
 
 	resp->resop = NFS4_OP_SETCLIENTID;
@@ -115,11 +116,12 @@ enum nfs_req_result nfs4_op_setclientid(struct nfs_argop4 *op,
 		 arg_SETCLIENTID4->callback.cb_location.r_netid,
 		 arg_SETCLIENTID4->callback_ident);
 
+	server_addr = get_raddr(data->req->rq_xprt);
 	/* Do we already have one or more records for client id (x)? */
 	client_record = get_client_record(arg_SETCLIENTID4->client.id.id_val,
 					  arg_SETCLIENTID4->client.id.id_len,
 					  0,
-					  0);
+					  server_addr);
 
 	if (client_record == NULL) {
 		/* Some major failure */

--- a/src/SAL/recovery/recovery_sfs_cluster.c
+++ b/src/SAL/recovery/recovery_sfs_cluster.c
@@ -140,7 +140,13 @@ static char *sfs_cluster_create_val(nfs_client_id_t *clientid, size_t *size)
 
 	struct in_addr s_addr;
 	s_addr.s_addr = htonl(clientid->cid_client_record->cr_server_addr);
-	char *str_server_addr = inet_ntoa(s_addr);
+	char str_server_addr[INET_ADDRSTRLEN];
+	const char *addr = inet_ntop(AF_INET, &s_addr, str_server_addr, INET_ADDRSTRLEN);
+	if (unlikely(addr == NULL)) {
+		LogFatal(COMPONENT_CLIENTID, "invalid server address: %u",
+			 clientid->cid_client_record->cr_server_addr);
+	}
+
 	int str_server_addr_len = strlen(str_server_addr);
 
 	lsize = str_client_addr_len + 2 + cidstr_lenx_len + 1 + cidstr_len + 3 + str_server_addr_len + 1;

--- a/src/include/sal_functions.h
+++ b/src/include/sal_functions.h
@@ -268,6 +268,8 @@ const char *clientid_error_to_str(clientid_status_t err);
 
 int nfs_Init_client_id(void);
 
+uint32_t get_raddr(SVCXPRT *xprt);
+
 clientid_status_t nfs_client_id_get_unconfirmed(clientid4 clientid,
 						nfs_client_id_t **pclient_rec);
 


### PR DESCRIPTION
1. also store server_address when nfs4_op_setclientid is called
2. use inet_ntop instead of inet_ntoa to ensure thread safety

v4 uses nfs4_op_setclientid instead of nfs4_op_exchange_id, nfs4_op_setclientid didn't set server addr, which causes add_clid in sfs recvory backend to panic