### PR TITLE
feat: modified fasl callback for setting a cookie

### DIFF
--- a/src/FSAL/FSAL_MEM/mem_handle.c
+++ b/src/FSAL/FSAL_MEM/mem_handle.c
@@ -2109,7 +2109,8 @@ out:
 
 fsal_status_t mem_commit2(struct fsal_obj_handle *obj_hdl,
 			  off_t offset,
-			  size_t len)
+			  size_t len,
+			  uint64_t *cookie)
 {
 	return fsalstat(ERR_FSAL_NO_ERROR, 0);
 }

--- a/src/FSAL/FSAL_PROXY_V3/main.c
+++ b/src/FSAL/FSAL_PROXY_V3/main.c
@@ -2051,7 +2051,8 @@ proxyv3_write2(struct fsal_obj_handle *obj_hdl,
 static fsal_status_t
 proxyv3_commit2(struct fsal_obj_handle *obj_hdl,
 		off_t offset,
-		size_t len)
+		size_t len,
+		uint64_t *cookie)
 {
 	struct proxyv3_obj_handle *obj =
 		container_of(obj_hdl, struct proxyv3_obj_handle, obj);

--- a/src/FSAL/FSAL_RGW/handle.c
+++ b/src/FSAL/FSAL_RGW/handle.c
@@ -1465,7 +1465,7 @@ void rgw_fsal_write2(struct fsal_obj_handle *obj_hdl,
  */
 
 fsal_status_t rgw_fsal_commit2(struct fsal_obj_handle *obj_hdl,
-			off_t offset, size_t length)
+			off_t offset, size_t length, uint64_t *cookie)
 {
 	int rc;
 

--- a/src/FSAL/FSAL_VFS/file.c
+++ b/src/FSAL/FSAL_VFS/file.c
@@ -1608,7 +1608,8 @@ fsal_status_t vfs_fallocate(struct fsal_obj_handle *obj_hdl,
 
 fsal_status_t vfs_commit2(struct fsal_obj_handle *obj_hdl,
 			  off_t offset,
-			  size_t len)
+			  size_t len,
+			  uint64_t *cookie)
 {
 	struct vfs_fsal_obj_handle *myself;
 	fsal_status_t status;

--- a/src/FSAL/FSAL_VFS/vfs_methods.h
+++ b/src/FSAL/FSAL_VFS/vfs_methods.h
@@ -333,7 +333,8 @@ fsal_status_t vfs_fallocate(struct fsal_obj_handle *obj_hdl,
 
 fsal_status_t vfs_commit2(struct fsal_obj_handle *obj_hdl,
 			  off_t offset,
-			  size_t len);
+			  size_t len,
+			  uint64_t *cookie);
 
 fsal_status_t vfs_lock_op2(struct fsal_obj_handle *obj_hdl,
 			   struct state_t *state,

--- a/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_file.c
+++ b/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_file.c
@@ -785,7 +785,7 @@ fsal_status_t mdcache_io_advise2(struct fsal_obj_handle *obj_hdl,
  * @return FSAL status
  */
 fsal_status_t mdcache_commit2(struct fsal_obj_handle *obj_hdl, off_t offset,
-			      size_t len)
+			      size_t len, uint64_t *cookie)
 {
 	mdcache_entry_t *entry =
 		container_of(obj_hdl, mdcache_entry_t, obj_handle);
@@ -793,7 +793,7 @@ fsal_status_t mdcache_commit2(struct fsal_obj_handle *obj_hdl, off_t offset,
 
 	subcall(
 		status = entry->sub_handle->obj_ops->commit2(
-			entry->sub_handle, offset, len)
+			entry->sub_handle, offset, len, cookie)
 	       );
 
 	if (status.major == ERR_FSAL_STALE)

--- a/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_int.h
+++ b/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_int.h
@@ -1079,7 +1079,7 @@ fsal_status_t mdcache_io_advise2(struct fsal_obj_handle *obj_hdl,
 				 struct state_t *state,
 				 struct io_hints *hints);
 fsal_status_t mdcache_commit2(struct fsal_obj_handle *obj_hdl, off_t offset,
-			      size_t len);
+			      size_t len, uint64_t *cookie);
 fsal_status_t mdcache_lock_op2(struct fsal_obj_handle *obj_hdl,
 			      struct state_t *state,
 			      void *p_owner,

--- a/src/FSAL/Stackable_FSALs/FSAL_NULL/file.c
+++ b/src/FSAL/Stackable_FSALs/FSAL_NULL/file.c
@@ -301,7 +301,7 @@ fsal_status_t nullfs_io_advise2(struct fsal_obj_handle *obj_hdl,
 }
 
 fsal_status_t nullfs_commit2(struct fsal_obj_handle *obj_hdl, off_t offset,
-			     size_t len)
+			     size_t len, uint64_t *cookie)
 {
 	struct nullfs_fsal_obj_handle *handle =
 		container_of(obj_hdl, struct nullfs_fsal_obj_handle,
@@ -315,7 +315,7 @@ fsal_status_t nullfs_commit2(struct fsal_obj_handle *obj_hdl, off_t offset,
 	op_ctx->fsal_export = export->export.sub_export;
 	fsal_status_t status =
 		handle->sub_handle->obj_ops->commit2(handle->sub_handle, offset,
-						    len);
+						    len, cookie);
 	op_ctx->fsal_export = &export->export;
 
 	return status;

--- a/src/FSAL/Stackable_FSALs/FSAL_NULL/nullfs_methods.h
+++ b/src/FSAL/Stackable_FSALs/FSAL_NULL/nullfs_methods.h
@@ -166,7 +166,7 @@ fsal_status_t nullfs_io_advise2(struct fsal_obj_handle *obj_hdl,
 				struct state_t *state,
 				struct io_hints *hints);
 fsal_status_t nullfs_commit2(struct fsal_obj_handle *obj_hdl, off_t offset,
-			     size_t len);
+			     size_t len, uint64_t *cookie);
 fsal_status_t nullfs_lock_op2(struct fsal_obj_handle *obj_hdl,
 			      struct state_t *state,
 			      void *p_owner,

--- a/src/FSAL/default_methods.c
+++ b/src/FSAL/default_methods.c
@@ -1438,7 +1438,8 @@ static fsal_status_t io_advise2(struct fsal_obj_handle *obj_hdl,
 
 static fsal_status_t commit2(struct fsal_obj_handle *obj_hdl,
 			     off_t offset,
-			     size_t len)
+			     size_t len,
+			     uint64_t *cookie)
 {
 	LogCrit(COMPONENT_FSAL,
 		"Invoking unsupported FSAL operation");

--- a/src/Protocols/NFS/nfs3_write.c
+++ b/src/Protocols/NFS/nfs3_write.c
@@ -83,7 +83,12 @@ static int nfs3_complete_write(struct nfs3_write_data *data)
 			resok->committed = UNSTABLE;
 
 		/* Set the write verifier */
-		memcpy(resok->verf, NFS3_write_verifier, sizeof(writeverf3));
+		if (write_arg->write_cookie){
+			memset(resok->verf, 0, sizeof(writeverf3));
+			*(uint64_t*)resok->verf = write_arg->write_cookie;
+		} else{
+			memcpy(resok->verf, NFS3_write_verifier, sizeof(writeverf3));
+		}
 	} else if (data->rc == NFS_REQ_ERROR) {
 		/* If we are here, there was an error */
 		nfs_SetWccData(NULL, data->obj, &resfail->file_wcc);
@@ -341,6 +346,7 @@ int nfs3_write(nfs_arg_t *arg, struct svc_req *req, nfs_res_t *res)
 	write_arg->iov[0].iov_len = size;
 	write_arg->iov[0].iov_base = arg->arg_write3.data.data_val;
 	write_arg->io_amount = 0;
+	write_arg->write_cookie = 0;
 
 	write_data->res = res;
 	write_data->req = req;

--- a/src/Protocols/NFS/nfs4_op_write.c
+++ b/src/Protocols/NFS/nfs4_op_write.c
@@ -78,8 +78,13 @@ static enum nfs_req_result nfs4_complete_write(struct nfs4_write_data *data)
 
 	verf_desc.addr = data->res_WRITE4->WRITE4res_u.resok4.writeverf;
 	verf_desc.len = sizeof(verifier4);
-	op_ctx->fsal_export->exp_ops.get_write_verifier(op_ctx->fsal_export,
-							&verf_desc);
+	if (write_arg->write_cookie){
+		memset(verf_desc.addr, 0, sizeof(verifier4));
+		*(uint64_t*)verf_desc.addr= write_arg->write_cookie;
+	} else{
+		op_ctx->fsal_export->exp_ops.get_write_verifier(op_ctx->fsal_export,
+								&verf_desc);
+	}
 
 done:
 
@@ -443,6 +448,7 @@ enum nfs_req_result nfs4_op_write(struct nfs_argop4 *op, compound_data_t *data,
 	write_arg->iov[0].iov_len = size;
 	write_arg->iov[0].iov_base = arg_WRITE4->data.data_val;
 	write_arg->io_amount = 0;
+	write_arg->write_cookie = 0;
 	write_arg->fsal_stable = arg_WRITE4->stable != UNSTABLE4 || force_sync;
 
 

--- a/src/include/fsal.h
+++ b/src/include/fsal.h
@@ -403,13 +403,11 @@ fsal_status_t fsal_statfs(struct fsal_obj_handle *obj,
  */
 static inline
 fsal_status_t fsal_commit(struct fsal_obj_handle *obj, off_t offset,
-			 size_t len)
+			 size_t len, uint64_t *cookie)
 {
-	if ((uint64_t) len > ~(uint64_t) offset)
-		return fsalstat(ERR_FSAL_INVAL, 0);
-
-	return obj->obj_ops->commit2(obj, offset, len);
+	return obj->obj_ops->commit2(obj, offset, len, cookie);
 }
+
 fsal_status_t fsal_verify2(struct fsal_obj_handle *obj,
 			   fsal_verifier_t verifier);
 

--- a/src/include/fsal_api.h
+++ b/src/include/fsal_api.h
@@ -1477,6 +1477,7 @@ typedef enum fsal_dir_result (*fsal_readdir_cb)(
  */
 struct fsal_io_arg {
 	size_t io_amount;	/**< Total amount of I/O actually done */
+	uint64_t write_cookie;
 	struct io_info *info;	/**< More info about data for read_plus */
 	union {
 		bool end_of_file;	/**< True if end-of-file reached */
@@ -2580,8 +2581,8 @@ struct fsal_obj_ops {
  */
 	 fsal_status_t (*commit2)(struct fsal_obj_handle *obj_hdl,
 				  off_t offset,
-				  size_t len);
-
+				  size_t len,
+				  uint64_t *cookie);
 /**
  * @brief Perform a lock operation
  *


### PR DESCRIPTION
The write2 and commit callback of fsal has the ability to set a cookie