### PR TITLE
feat(lock): skip unlock from some FSAL on vip detached

### DIFF
--- a/src/FSAL/fsal_config.c
+++ b/src/FSAL/fsal_config.c
@@ -75,6 +75,8 @@ bool fsal_supports(struct fsal_staticfsinfo_t *info,
 		return !!info->lock_support;
 	case fso_lock_support_async_block:
 		return !!info->lock_support_async_block;
+	case fso_lock_full_control:
+		return !!info->lock_full_control;
 	case fso_named_attr:
 		return !!info->named_attr;
 	case fso_unique_handles:

--- a/src/SAL/state_lock.c
+++ b/src/SAL/state_lock.c
@@ -2173,6 +2173,8 @@ state_status_t do_lock_op(struct fsal_obj_handle *obj,
 	 * Lock owners are not supported and hint tells us that lock fully
 	 *   overlaps a lock we already have (no need to make another FSAL
 	 *   call in that case)
+	 * Unlock of stale nfs4_clientid and some FSAL need the existence
+	 * of lock record to check the future lock reclaim.
 	 *
 	 * We do NOT need to quick exit if async blocking locks are not
 	 * supported and there is an overlap because we won't get here if
@@ -2234,6 +2236,16 @@ state_status_t do_lock_op(struct fsal_obj_handle *obj,
 		nfs4_clientid = owner->so_owner.so_nfs4_owner.so_clientrec;
 		owner_client = nfs4_clientid->gsh_client;
 		break;
+	}
+
+	if (fsal_lock_op == FSAL_OP_UNLOCK
+	    && nfs4_clientid != NULL
+	    && nfs4_clientid->cid_confirmed == STALE_CLIENT_ID
+	    && fsal_export->exp_ops.fs_supports(
+			  fsal_export, fso_lock_full_control)) {
+		LogDebug(COMPONENT_STATE,
+			 "skip unlock of stale nfs4_clientid. FSAL need the lock record to check lock reclaim");
+		return STATE_SUCCESS;
 	}
 
 	/* If the owner gsh_client doesn't match the op_ctx and is not NULL

--- a/src/include/fsal_types.h
+++ b/src/include/fsal_types.h
@@ -658,6 +658,7 @@ typedef enum enum_fsal_fsinfo_options {
 	fso_symlink_support,
 	fso_lock_support,
 	fso_lock_support_async_block,
+	fso_lock_full_control,
 	fso_named_attr,
 	fso_unique_handles,
 	fso_cansettime,
@@ -699,6 +700,9 @@ typedef struct fsal_staticfsinfo_t {
 	bool symlink_support;	/*< FS supports symlinks? */
 	bool lock_support;	/*< FS supports file locking? */
 	bool lock_support_async_block;	/*< FS supports blocking locks? */
+	bool lock_full_control; /*< FS persists enough about file locking?
+				    FS checks strictly about whether to grant
+				    or reclaim lock. */
 	bool named_attr;	/*< FS supports named attributes. */
 	bool unique_handles;	/*< Handles are unique and persistent. */
 	fsal_aclsupp_t acl_support;	/*< what type of ACLs are supported */


### PR DESCRIPTION
Some FSAL persists enough information about lock. Itself can control whether to reclaim lock, not completely trusting NFS client. If VIP is detached, the FSAL expects lock record keep in the backend storage, which is used to check following reclaim.

See https://github.com/nfs-ganesha/nfs-ganesha/issues/1108