### PR TITLE
Add new config parameter that controls the unique server_id

### DIFF
--- a/src/MainNFSD/nfs_init.c
+++ b/src/MainNFSD/nfs_init.c
@@ -1005,7 +1005,7 @@ void nfs_start(nfs_start_info_t *p_start_info)
 			uint64_t epoch;
 		} build_verifier;
 
-		build_verifier.epoch = (uint64_t) nfs_ServerEpoch;
+		build_verifier.epoch = get_unique_server_id();
 
 		memcpy(NFS3_write_verifier, build_verifier.NFS3_write_verifier,
 		       sizeof(NFS3_write_verifier));

--- a/src/SAL/nfs4_clientid.c
+++ b/src/SAL/nfs4_clientid.c
@@ -1160,12 +1160,12 @@ clientid_status_t nfs_client_id_get(hash_table_t *ht, clientid4 clientid,
 	struct gsh_buffdesc buffkey;
 	struct gsh_buffdesc buffval;
 	clientid_status_t status;
-	uint64_t epoch_low = nfs_ServerEpoch & 0xFFFFFFFF;
+	uint64_t unique_prefix = get_unique_server_id() & 0xFFFFFFFF;
 	uint64_t cid_epoch = (uint64_t) (clientid >> (clientid4) 32);
 	nfs_client_id_t *pclientid;
 
-	/* Don't even bother to look up clientid if epochs don't match */
-	if (cid_epoch != epoch_low) {
+	/* Don't bother to look up clientid if unique prefixes don't match */
+	if (cid_epoch != unique_prefix) {
 		if (isDebug(COMPONENT_HASHTABLE))
 			LogFullDebug(COMPONENT_CLIENTID,
 				     "%s NOTFOUND (epoch doesn't match, assumed STALE)",
@@ -1278,21 +1278,21 @@ int display_clientid(struct display_buffer *dspbuf, clientid4 clientid)
 {
 	int b_left = display_buffer_remain(dspbuf);
 	uint32_t counter = clientid & UINT32_MAX;
-	uint32_t epoch = clientid >> (clientid4) 32;
+	uint32_t unique = clientid >> (clientid4) 32;
 
 	if (b_left <= 0)
 		return b_left;
 
-	return display_printf(dspbuf, "Epoch=0x%08"PRIx32" Counter=0x%08"PRIx32,
-			      epoch, counter);
+	return display_printf(dspbuf, "Unique=0x%08"PRIx32
+			" Counter=0x%08"PRIx32, unique, counter);
 }
 
 /**
  * @brief Builds a new clientid4 value
  *
- * We use the clientid counter and the server epoch, the latter
- * ensures that clientids from old instances of Ganesha are marked as
- * invalid.
+ * We use the clientid counter and the server epoch or a value supplied in the
+ * config, the latter should ensure that clientids from old instances of
+ * Ganesha are marked as invalid.
  *
  * @return The new clientid.
  */
@@ -1300,9 +1300,7 @@ int display_clientid(struct display_buffer *dspbuf, clientid4 clientid)
 clientid4 new_clientid(void)
 {
 	clientid4 newid = atomic_inc_uint32_t(&clientid_counter);
-	uint64_t epoch_low = nfs_ServerEpoch & UINT32_MAX;
-
-	return newid + (epoch_low << (clientid4) 32);
+	return newid + (clientid4)(get_unique_server_id() << 32);
 }
 
 /**

--- a/src/SAL/nfs4_state_id.c
+++ b/src/SAL/nfs4_state_id.c
@@ -795,8 +795,8 @@ nfsstat4 nfs4_Check_Stateid(stateid4 *stateid, struct fsal_obj_handle *fsal_obj,
 			    seqid4 owner_seqid, bool check_seqid,
 			    const char *tag)
 {
-	uint32_t epoch = 0;
-	uint64_t epoch_low = nfs_ServerEpoch & 0xFFFFFFFF;
+	uint32_t client_unique_prefix = 0;
+	uint64_t unique_prefix = get_unique_server_id() & 0xFFFFFFFF;
 	state_t *state2 = NULL;
 	struct fsal_obj_handle *obj2 = NULL;
 	state_owner_t *owner2 = NULL;
@@ -893,10 +893,10 @@ nfsstat4 nfs4_Check_Stateid(stateid4 *stateid, struct fsal_obj_handle *fsal_obj,
 	memcpy(&clientid, stateid->other, sizeof(clientid));
 
 	/* Extract the epoch from the clientid */
-	epoch = clientid >> (clientid4) 32;
+	client_unique_prefix = clientid >> (clientid4) 32;
 
 	/* Check if stateid was made from this server instance */
-	if (epoch != epoch_low) {
+	if (client_unique_prefix != unique_prefix) {
 		if (str_valid)
 			LogDebug(COMPONENT_STATE,
 				 "Check %s stateid found stale stateid %s",

--- a/src/SAL/state_misc.c
+++ b/src/SAL/state_misc.c
@@ -1351,4 +1351,18 @@ void state_release_export(struct gsh_export *export)
 	release_op_context();
 }
 
+/**
+ * @brief Gets a unique server id to be used for base of client id
+ * the value should be diffrent from old and diffrent instances of ganesha
+ *
+ * @return unique server id.
+ */
+
+uint64_t get_unique_server_id(void)
+{
+	if (nfs_param.core_param.unique_server_id != 0)
+		return nfs_param.core_param.unique_server_id;
+	return nfs_ServerEpoch & UINT32_MAX;
+}
+
 /** @} */

--- a/src/config_samples/config.txt
+++ b/src/config_samples/config.txt
@@ -199,6 +199,8 @@ NFS_CORE_PARAM {}
 
 	enable_rpc_cred_fallback(bool, default false)
 
+	Unique_Server_Id(uint32, range 0 to UINT32_MAX, default 0)
+
 NFS_IP_NAME {}
 --------------
 

--- a/src/doc/man/ganesha-core-config.rst
+++ b/src/doc/man/ganesha-core-config.rst
@@ -222,6 +222,12 @@ enable_rpc_cred_fallback(bool,  default false)
     then use gid data from rpc request.
 
 
+Unique_Server_Id(uint32, range 0 to UINT32_MAX, default 0)
+   Unique value to the ganesha node, to diffrintiate it for the rest of the
+   node. will be used as prefix for the Client id, to make sure it is
+   unique between ganesha nodes and file write verifier.
+   if 0 is supplied server boot epoch time in seconds will be used
+
 Parameters controlling TCP DRC behavior:
 ----------------------------------------
 

--- a/src/include/gsh_config.h
+++ b/src/include/gsh_config.h
@@ -482,6 +482,8 @@ typedef struct nfs_core_param {
 	/** if  Manage_Gids=True and group resolution fails,
 	 *  then use gid data from rpc request */
 	bool enable_rpc_cred_fallback;
+	/** unique server id, if 0 will use start time **/
+	uint32_t unique_server_id;
 } nfs_core_parameter_t;
 
 /** @} */

--- a/src/include/sal_functions.h
+++ b/src/include/sal_functions.h
@@ -115,6 +115,8 @@ void dump_all_owners(void);
 
 void state_release_export(struct gsh_export *exp);
 
+uint64_t get_unique_server_id(void);
+
 bool state_unlock_err_ok(state_status_t status);
 
 /**

--- a/src/log/log_functions.c
+++ b/src/log/log_functions.c
@@ -57,6 +57,7 @@
 
 #include "nfs_core.h"
 #include "config_parsing.h"
+#include "sal_functions.h"
 
 #ifdef USE_LTTNG
 #include "gsh_lttng/logger.h"
@@ -523,7 +524,7 @@ void set_const_log_str(void)
 
 	if (b_left > 0 && logfields->disp_epoch)
 		b_left = display_printf(&dspbuf,
-			": epoch %08lx ", (unsigned long) nfs_ServerEpoch);
+			": epoch %08lx ", get_unique_server_id());
 
 	if (b_left > 0 && logfields->disp_host)
 		b_left = display_printf(&dspbuf, ": %s ", hostname);

--- a/src/support/nfs_read_conf.c
+++ b/src/support/nfs_read_conf.c
@@ -331,6 +331,8 @@ static struct config_item core_params[] = {
 #endif
 	CONF_ITEM_BOOL("enable_rpc_cred_fallback", false,
 		       nfs_core_param, enable_rpc_cred_fallback),
+	CONF_ITEM_UI32("Unique_Server_Id", 0, UINT32_MAX, 0,
+			nfs_core_param, unique_server_id),
 	CONFIG_EOL
 };
 


### PR DESCRIPTION
if value is 0, use server start time in seconds (as was before) if not get a unique number for configuration.
this is similiar to the -E flag, but is useful when ganesha is setup as a service

Change-Id: I8bc47ebbfd6eededa2ef746e34ba031c5e72c169




<!--
  - STOP

  - The NFS-Ganesha Project uses gerrithub to review patch submissions

  - See src/CONTRIBUTING_HOWTO.txt or [DevPolicy](https://github.com/nfs-ganesha/nfs-ganesha/wiki/DevPolicy)

  - In a nutshell, here's how to submit a patch for NFS-Ganesha to gerrithub

```
$ git clone ssh://USERNAMEHERE@review.gerrithub.io:29418/ffilz/nfs-ganesha
 $ cd nfs-ganesha
 nfs-ganesha$ git remote add gerrit ssh://USERNAMEHERE@review.gerrithub.io:29418/ffilz/nfs-ganesha
 nfs-ganesha$ git fetch gerrit
 nfs-ganesha$ ./src/scripts/git_hooks/install_git_hooks.sh
 nfs-ganesha$ git log gerrit/next..HEAD
 # this should ONLY list the commits you want to push!
 nfs-ganesha$ git push gerrit HEAD:refs/for/next
```

  - Look for your patch at [GerritHub](https://review.gerrithub.io/dashboard/self)

-->
