### PR TITLE
fix(readdir): fixed exception that attr are overridden by ganesha

### DIFF
--- a/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_helpers.c
+++ b/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_helpers.c
@@ -890,7 +890,7 @@ mdcache_new_entry(struct mdcache_fsal_export *export,
 	 * NOTE: There can not be an ABBA lock ordering issue since our caller
 	 *        does not hold a lock on the "new" entry.
 	 */
-	if (prefer_attrs_in && !FSAL_IS_ERROR(status) && attrs_out != NULL) {
+	if (prefer_attrs_in && !FSAL_IS_ERROR(status)) {
 		PTHREAD_RWLOCK_wrlock(&(*entry)->attr_lock);
 		mdc_update_attr_cache(*entry, attrs_in);
 		PTHREAD_RWLOCK_unlock(&(*entry)->attr_lock);


### PR DESCRIPTION
The issue introduced earlier when resolving the Ganesha crash.

