### PR TITLE
fix(readdir): encode "next entry" flag in readdir reply

### DIFF
--- a/src/Protocols/NFS/nfs3_readdir.c
+++ b/src/Protocols/NFS/nfs3_readdir.c
@@ -333,20 +333,18 @@ int nfs3_readdir(nfs_arg_t *arg, struct svc_req *req, nfs_res_t *res)
 		u_int pos_end;
 		bool_t tmp;
 
-		if (eod_met) {
-			/* If we hit end of directory, then the dirlist3 we have
-			 * encoded so far has a complete entry (we MUST have
-			 * consumed the last entry and encoded it). Now we need
-			 * to encode a FALSE to indicate no next entry.
-			 */
-			tmp = FALSE;
-			if (!xdr_bool(&tracker.xdr, &tmp)) {
-				/* Oops... */
-				LogCrit(COMPONENT_NFS_READDIR,
-					"Encode of no next entry failed.");
-				res->res_readdir3.status = NFS3ERR_SERVERFAULT;
-				goto out_destroy;
-			}
+		/* The dirlist3 we have encoded so far has a complete
+		 * entry (we MUST have consumed the last entry and
+		 * encoded it). Now we need to encode a FALSE to
+		 * indicate no next entry.
+		 */
+		tmp = FALSE;
+		if (!xdr_bool(&tracker.xdr, &tmp)) {
+			/* Oops... */
+			LogCrit(COMPONENT_NFS_READDIR,
+				"Encode of no next entry failed.");
+			res->res_readdir3.status = NFS3ERR_SERVERFAULT;
+			goto out_destroy;
 		}
 
 		/* Serialize eod_met into the entries buffer */
@@ -459,17 +457,12 @@ fsal_errors_t nfs3_readdir_callback(void *opaque,
 	    !xdr_encode_entry3(&tracker->xdr, &e3) ||
 	    (xdr_getpos(&tracker->xdr) + BYTES_PER_XDR_UNIT)
 	    >= tracker->mem_avail) {
-		bool_t res_false = false;
-
 		/* XDR serialization of the entry failed or we ran out of room
 		 * to serialize at least a boolean after the result. */
 		cb_parms->in_result = false;
 
-		/* Reset to where we started this entry and encode a boolean
-		 * false instead (entry_follows is false).
-		 */
-		if (!xdr_setpos(&tracker->xdr, pos_start) ||
-		    !xdr_bool(&tracker->xdr, &res_false)) {
+		/* Reset to where we started this entry */
+		if (!xdr_setpos(&tracker->xdr, pos_start)) {
 			/* Oops, what broke... */
 			LogCrit(COMPONENT_NFS_READDIR,
 				"Unexpected XDR failure processing readdir result");

--- a/src/Protocols/NFS/nfs3_readdirplus.c
+++ b/src/Protocols/NFS/nfs3_readdirplus.c
@@ -346,21 +346,18 @@ int nfs3_readdirplus(nfs_arg_t *arg, struct svc_req *req, nfs_res_t *res)
 		u_int pos_end;
 		bool_t tmp;
 
-		if (eod_met) {
-			/* If we hit end of directory, then the dirlist3 we have
-			 * encoded so far has a complete entry (we MUST have
-			 * consumed the last entry and encoded it). Now we need
-			 * to encode a FALSE to indicate no next entry.
-			 */
-			tmp = FALSE;
-			if (!xdr_bool(&tracker.xdr, &tmp)) {
-				/* Oops... */
-				LogCrit(COMPONENT_NFS_READDIR,
-					"Encode of no next entry failed.");
-				res->res_readdirplus3.status
-					= NFS3ERR_SERVERFAULT;
-				goto out_destroy;
-			}
+		/* The dirlistplus3 we have encoded so far has a complete
+		 * entry (we MUST have consumed the last entry and
+		 * encoded it). Now we need to encode a FALSE to
+		 * indicate no next entry.
+		 */
+		tmp = FALSE;
+		if (!xdr_bool(&tracker.xdr, &tmp)) {
+			/* Oops... */
+			LogCrit(COMPONENT_NFS_READDIR,
+				"Encode of no next entry failed.");
+			res->res_readdirplus3.status = NFS3ERR_SERVERFAULT;
+			goto out_destroy;
 		}
 
 		/* Serialize eod_met into the entries buffer */
@@ -512,17 +509,12 @@ fsal_errors_t nfs3_readdirplus_callback(void *opaque,
 	    !xdr_encode_entryplus3(&tracker->xdr, &ep3, attr) ||
 	    (xdr_getpos(&tracker->xdr) + BYTES_PER_XDR_UNIT)
 	    >= tracker->mem_avail) {
-		bool_t res_false = false;
-
 		/* XDR serialization of the entry failed or we ran out of room
 		 * to serialize at least a boolean after the result. */
 		cb_parms->in_result = false;
 
-		/* Reset to where we started this entry and encode a boolean
-		 * false instead (entry_follows is false).
-		 */
-		if (!xdr_setpos(&tracker->xdr, pos_start) ||
-		    !xdr_bool(&tracker->xdr, &res_false)) {
+		/* Reset to where we started this entry. */
+		if (!xdr_setpos(&tracker->xdr, pos_start)) {
 			/* Oops, what broke... */
 			LogCrit(COMPONENT_NFS_READDIR,
 				"Unexpected XDR failure processing readdir result");

--- a/src/Protocols/NFS/nfs4_op_readdir.c
+++ b/src/Protocols/NFS/nfs4_op_readdir.c
@@ -116,7 +116,6 @@ fsal_errors_t nfs4_readdir_callback(void *opaque,
 	u_int pos_start = xdr_getpos(&tracker->xdr);
 	u_int mem_left = tracker->mem_avail - pos_start;
 	component4 name;
-	bool_t res_false = false;
 	bool_t lock_dir = false;
 	struct fsal_obj_handle *saved_current_obj = NULL;
 
@@ -467,11 +466,8 @@ not_junction:
 
  failure:
 
-	/* Reset to where we started this entry and encode a boolean
-	 * false instead (entry_follows is false).
-	 */
-	if (!xdr_setpos(&tracker->xdr, pos_start) ||
-	    !xdr_bool(&tracker->xdr, &res_false)) {
+	/* Reset to where we started this entry. */
+	if (!xdr_setpos(&tracker->xdr, pos_start)) {
 		/* Oops, what broke... */
 		LogCrit(COMPONENT_NFS_READDIR,
 			"Unexpected XDR failure processing readdir result");
@@ -726,20 +722,18 @@ enum nfs_req_result nfs4_op_readdir(struct nfs_argop4 *op,
 		u_int pos_end;
 		bool_t tmp;
 
-		if (eod_met) {
-			/* If we hit end of directory, then the dirlist4 we have
-			 * encoded so far has a complete entry (we MUST have
-			 * consumed the last entry and encoded it). Now we need
-			 * to encode a FALSE to indicate no next entry.
-			 */
-			tmp = FALSE;
-			if (!xdr_bool(&tracker.xdr, &tmp)) {
-				/* Oops... */
-				LogCrit(COMPONENT_NFS_READDIR,
-					"Encode of no next entry failed.");
-				res_READDIR4->status = NFS4ERR_SERVERFAULT;
-				goto out_destroy;
-			}
+		/* The dirlist4 we have encoded so far has a complete
+		 * entry (we MUST have consumed the last entry and
+		 * encoded it). Now we need to encode a FALSE to
+		 * indicate no next entry.
+		 */
+		tmp = FALSE;
+		if (!xdr_bool(&tracker.xdr, &tmp)) {
+			/* Oops... */
+			LogCrit(COMPONENT_NFS_READDIR,
+				"Encode of no next entry failed.");
+			res_READDIR4->status = NFS4ERR_SERVERFAULT;
+			goto out_destroy;
 		}
 
 		/* Serialize eod_met into the entries buffer */


### PR DESCRIPTION
This commit resolves the issue described in #1234.

When FSAL readdir completes without hitting both EOF of the directory and DIR_TERMINATE in the readdir callback, the "next entry" flag is missing in the reply. This causes the Windows NFS client to misinterpret the directory as empty in File Explorer, while the Linux NFS client handles it correctly.

The fix ensures that the "next entry" flag is included in the readdir reply in this scenario, allowing Windows clients to correctly display the directory contents.

Change-Id: I594b03073d9023d1d05ab889f9fbd1a577b603fa




<!--
  - STOP

  - The NFS-Ganesha Project uses gerrithub to review patch submissions

  - See src/CONTRIBUTING_HOWTO.txt or [DevPolicy](https://github.com/nfs-ganesha/nfs-ganesha/wiki/DevPolicy)

  - In a nutshell, here's how to submit a patch for NFS-Ganesha to gerrithub

```
$ git clone ssh://USERNAMEHERE@review.gerrithub.io:29418/ffilz/nfs-ganesha
 $ cd nfs-ganesha
 nfs-ganesha$ git remote add gerrit ssh://USERNAMEHERE@review.gerrithub.io:29418/ffilz/nfs-ganesha
 nfs-ganesha$ git fetch gerrit
 nfs-ganesha$ ./src/scripts/git_hooks/install_git_hooks.sh
 nfs-ganesha$ git log gerrit/next..HEAD
 # this should ONLY list the commits you want to push!
 nfs-ganesha$ git push gerrit HEAD:refs/for/next
```

  - Look for your patch at [GerritHub](https://review.gerrithub.io/dashboard/self)

-->
