### PR TITLE
ganesha-sfs 1.2.x: only evicts completed entries in duplicate reply cache layer

### DIFF
--- a/src/RPCAL/nfs_dupreq.c
+++ b/src/RPCAL/nfs_dupreq.c
@@ -1164,9 +1164,7 @@ dupreq_status_t nfs_dupreq_start(nfs_request_t *reqnfs)
 			 */
 			dk->refcnt = 2;
 
-			/* add to q tail */
 			PTHREAD_MUTEX_lock(&drc->drc_mtx);
-			TAILQ_INSERT_TAIL(&drc->dupreq_q, dk, fifo_q);
 			++(drc->size);
 			PTHREAD_MUTEX_unlock(&drc->drc_mtx);
 
@@ -1257,6 +1255,9 @@ void nfs_dupreq_finish(nfs_request_t *reqnfs, enum nfs_req_result rc)
 		     dv, dv->hin.tcp.rq_xid, drc,
 		     dupreq_state_table[dv->complete],
 		     dv->refcnt, drc->size);
+
+	/* add to the tail of complete queue */
+	TAILQ_INSERT_TAIL(&drc->dupreq_q, dv, fifo_q);
 
 	/* (all) finished requests count against retwnd */
 	drc_dec_retwnd(drc);
@@ -1382,24 +1383,8 @@ void nfs_dupreq_delete(nfs_request_t *reqnfs, enum nfs_req_result rc)
 		     dupreq_state_table[dv->complete],
 		     dv->refcnt);
 
-	/* This function is called to remove this dupreq from the
-	 * hashtable/list, but it is possible that another thread
-	 * processing a different request calling nfs_dupreq_finish()
-	 * might have already deleted this dupreq.
-	 *
-	 * If this dupreq is already removed from hash table/list, do
-	 * nothing.
-	 *
-	 * req holds a ref on drc, so it should be valid here.
-	 * assert(drc == (drc_t *)reqnfs->svc.rq_xprt->xp_u2);
-	 */
 	PTHREAD_MUTEX_lock(&drc->drc_mtx);
-	if (!TAILQ_IS_ENQUEUED(dv, fifo_q)) {
-		PTHREAD_MUTEX_unlock(&drc->drc_mtx);
-		return; /* no more in the hash table/list, nothing todo */
-	}
-	TAILQ_REMOVE(&drc->dupreq_q, dv, fifo_q);
-	TAILQ_INIT_ENTRY(dv, fifo_q);
+	assert(!TAILQ_IS_ENQUEUED(dv, fifo_q));
 	--(drc->size);
 	PTHREAD_MUTEX_unlock(&drc->drc_mtx);
 

--- a/src/RPCAL/nfs_dupreq.c
+++ b/src/RPCAL/nfs_dupreq.c
@@ -1351,10 +1351,19 @@ void nfs_dupreq_delete(nfs_request_t *reqnfs, enum nfs_req_result rc)
 	if (dv == DUPREQ_NOCACHE || dv == DUPREQ_NOCACHE_NORES)
 		return;
 
+	drc = reqnfs->svc.rq_xprt->xp_u2;
+
 	/* Check if this entry has any duplicate requests queued against it. If
 	 * so, we will want to resubmit them and NOT delete this drc. It will
 	 * attach as primary to the next request in line.
+	 *
+	 * If partition lock of rb tree is not acquired here, nfs_dupreq_start()
+	 * may find and use an existent entry in the hash table. However, we're
+	 * removing the entry here.
 	 */
+	t = rbtx_partition_of_scalar(&drc->xt, dv->hk);
+	PTHREAD_MUTEX_lock(&t->mtx);
+
 	PTHREAD_MUTEX_lock(&dv->dre_mtx);
 
 	if (!TAILQ_EMPTY(&dv->dupes)) {
@@ -1369,12 +1378,11 @@ void nfs_dupreq_delete(nfs_request_t *reqnfs, enum nfs_req_result rc)
 		dv->rc = rc;
 
 		PTHREAD_MUTEX_unlock(&dv->dre_mtx);
+		PTHREAD_MUTEX_unlock(&t->mtx);
 		return;
 	}
 
 	PTHREAD_MUTEX_unlock(&dv->dre_mtx);
-
-	drc = reqnfs->svc.rq_xprt->xp_u2;
 
 	LogFullDebug(COMPONENT_DUPREQ,
 		     "deleting dv=%p xid=%" PRIu32
@@ -1388,9 +1396,6 @@ void nfs_dupreq_delete(nfs_request_t *reqnfs, enum nfs_req_result rc)
 	--(drc->size);
 	PTHREAD_MUTEX_unlock(&drc->drc_mtx);
 
-	t = rbtx_partition_of_scalar(&drc->xt, dv->hk);
-
-	PTHREAD_MUTEX_lock(&t->mtx);
 	rbtree_x_cached_remove(&drc->xt, t, &dv->rbt_k, dv->hk);
 	PTHREAD_MUTEX_unlock(&t->mtx);
 

--- a/src/RPCAL/nfs_dupreq.c
+++ b/src/RPCAL/nfs_dupreq.c
@@ -1226,6 +1226,9 @@ void nfs_dupreq_finish(nfs_request_t *reqnfs, enum nfs_req_result rc)
 
 	PTHREAD_MUTEX_lock(&dv->dre_mtx);
 
+	/* the next duplicate handles different results separately */
+	dv->rc = rc;
+
 	assert(dv->res == reqnfs->res_nfs);
 
 	/* Now see if there are any requests waiting. */
@@ -1242,7 +1245,6 @@ void nfs_dupreq_finish(nfs_request_t *reqnfs, enum nfs_req_result rc)
 	}
 
 	dv->complete = true;
-	dv->rc = rc;
 
 	PTHREAD_MUTEX_unlock(&dv->dre_mtx);
 


### PR DESCRIPTION


<!--
  - STOP

  - The NFS-Ganesha Project uses gerrithub to review patch submissions

  - See src/CONTRIBUTING_HOWTO.txt or [DevPolicy](https://github.com/nfs-ganesha/nfs-ganesha/wiki/DevPolicy)

  - In a nutshell, here's how to submit a patch for NFS-Ganesha to gerrithub

```
$ git clone ssh://USERNAMEHERE@review.gerrithub.io:29418/ffilz/nfs-ganesha
 $ cd nfs-ganesha
 nfs-ganesha$ git remote add gerrit ssh://USERNAMEHERE@review.gerrithub.io:29418/ffilz/nfs-ganesha
 nfs-ganesha$ git fetch gerrit
 nfs-ganesha$ ./src/scripts/git_hooks/install_git_hooks.sh
 nfs-ganesha$ git log gerrit/next..HEAD
 # this should ONLY list the commits you want to push!
 nfs-ganesha$ git push gerrit HEAD:refs/for/next
```

  - Look for your patch at [GerritHub](https://review.gerrithub.io/dashboard/self)

-->
