### PR TITLE
Pick from 1.2.x again: do NOT retire inflight DRC entries

### DIFF
--- a/src/RPCAL/nfs_dupreq.c
+++ b/src/RPCAL/nfs_dupreq.c
@@ -1164,10 +1164,10 @@ dupreq_status_t nfs_dupreq_start(nfs_request_t *reqnfs)
 			 */
 			dk->refcnt = 2;
 
-			/* add to q tail */
 			PTHREAD_MUTEX_lock(&drc->drc_mtx);
-			TAILQ_INSERT_TAIL(&drc->dupreq_q, dk, fifo_q);
+			/* count both inflight and completed entries */
 			++(drc->size);
+			/* inflight entry is not added to the dupreq_q */
 			PTHREAD_MUTEX_unlock(&drc->drc_mtx);
 
 			LogFullDebug(COMPONENT_DUPREQ,
@@ -1192,19 +1192,21 @@ no_cache:
 /**
  * @brief Completes a request in the cache
  *
- * Completes a cache insertion operation begun in nfs_dupreq_start.
+ * Completes a cache insertion operation begun in nfs_dupreq_start by
+ * marking the entry completed and adding the entry into dupreq_q.
  * The refcnt of the corresponding duplicate request entry is unchanged
  * (ie, the caller must still call nfs_dupreq_rele).
  *
  * In contrast with the prior DRC implementation, completing a request
  * in the current implementation may under normal conditions cause one
- * or more cached requests to be retired.  Requests are retired in the
- * order they were inserted.  The primary retire algorithm is a high
- * water mark, and a windowing heuristic.  One or more requests will be
- * retired if the water mark/timeout is exceeded, and if a no duplicate
- * requests have been found in the cache in a configurable window of
- * immediately preceding requests.  A timeout may supplement the water mark,
- * in future.
+ * or more cached requests to be retired. Entries can be retired only
+ * when they complete and they are retired in the order they complete.
+ *
+ * The primary retire algorithm is a high water mark, and a windowing
+ * heuristic. One or more requests will be retired if the water
+ * mark/timeout is exceeded, and if a no duplicate requests have been
+ * found in the cache in a configurable window of immediately preceding
+ * requests. A timeout may supplement the water mark, in future.
  *
  * req->rq_u1 has either a magic value, or points to a duplicate request
  * cache entry allocated in nfs_dupreq_start.
@@ -1226,6 +1228,9 @@ void nfs_dupreq_finish(nfs_request_t *reqnfs, enum nfs_req_result rc)
 
 	PTHREAD_MUTEX_lock(&dv->dre_mtx);
 
+	/* the next duplicate handles different results separately */
+	dv->rc = rc;
+
 	assert(dv->res == reqnfs->res_nfs);
 
 	/* Now see if there are any requests waiting. */
@@ -1242,7 +1247,6 @@ void nfs_dupreq_finish(nfs_request_t *reqnfs, enum nfs_req_result rc)
 	}
 
 	dv->complete = true;
-	dv->rc = rc;
 
 	PTHREAD_MUTEX_unlock(&dv->dre_mtx);
 
@@ -1255,6 +1259,9 @@ void nfs_dupreq_finish(nfs_request_t *reqnfs, enum nfs_req_result rc)
 		     dv, dv->hin.tcp.rq_xid, drc,
 		     dupreq_state_table[dv->complete],
 		     dv->refcnt, drc->size);
+
+	/* add to the tail of complete queue */
+	TAILQ_INSERT_TAIL(&drc->dupreq_q, dv, fifo_q);
 
 	/* (all) finished requests count against retwnd */
 	drc_dec_retwnd(drc);
@@ -1348,10 +1355,19 @@ void nfs_dupreq_delete(nfs_request_t *reqnfs, enum nfs_req_result rc)
 	if (dv == DUPREQ_NOCACHE || dv == DUPREQ_NOCACHE_NORES)
 		return;
 
+	drc = reqnfs->svc.rq_xprt->xp_u2;
+
 	/* Check if this entry has any duplicate requests queued against it. If
 	 * so, we will want to resubmit them and NOT delete this drc. It will
 	 * attach as primary to the next request in line.
+	 *
+	 * If partition lock of rb tree is not acquired here, nfs_dupreq_start()
+	 * may find and use an existent entry in the hash table. However, we're
+	 * removing the entry here.
 	 */
+	t = rbtx_partition_of_scalar(&drc->xt, dv->hk);
+	PTHREAD_MUTEX_lock(&t->mtx);
+
 	PTHREAD_MUTEX_lock(&dv->dre_mtx);
 
 	if (!TAILQ_EMPTY(&dv->dupes)) {
@@ -1366,12 +1382,11 @@ void nfs_dupreq_delete(nfs_request_t *reqnfs, enum nfs_req_result rc)
 		dv->rc = rc;
 
 		PTHREAD_MUTEX_unlock(&dv->dre_mtx);
+		PTHREAD_MUTEX_unlock(&t->mtx);
 		return;
 	}
 
 	PTHREAD_MUTEX_unlock(&dv->dre_mtx);
-
-	drc = reqnfs->svc.rq_xprt->xp_u2;
 
 	LogFullDebug(COMPONENT_DUPREQ,
 		     "deleting dv=%p xid=%" PRIu32
@@ -1380,30 +1395,11 @@ void nfs_dupreq_delete(nfs_request_t *reqnfs, enum nfs_req_result rc)
 		     dupreq_state_table[dv->complete],
 		     dv->refcnt);
 
-	/* This function is called to remove this dupreq from the
-	 * hashtable/list, but it is possible that another thread
-	 * processing a different request calling nfs_dupreq_finish()
-	 * might have already deleted this dupreq.
-	 *
-	 * If this dupreq is already removed from hash table/list, do
-	 * nothing.
-	 *
-	 * req holds a ref on drc, so it should be valid here.
-	 * assert(drc == (drc_t *)reqnfs->svc.rq_xprt->xp_u2);
-	 */
 	PTHREAD_MUTEX_lock(&drc->drc_mtx);
-	if (!TAILQ_IS_ENQUEUED(dv, fifo_q)) {
-		PTHREAD_MUTEX_unlock(&drc->drc_mtx);
-		return; /* no more in the hash table/list, nothing todo */
-	}
-	TAILQ_REMOVE(&drc->dupreq_q, dv, fifo_q);
-	TAILQ_INIT_ENTRY(dv, fifo_q);
+	assert(!TAILQ_IS_ENQUEUED(dv, fifo_q));
 	--(drc->size);
 	PTHREAD_MUTEX_unlock(&drc->drc_mtx);
 
-	t = rbtx_partition_of_scalar(&drc->xt, dv->hk);
-
-	PTHREAD_MUTEX_lock(&t->mtx);
 	rbtree_x_cached_remove(&drc->xt, t, &dv->rbt_k, dv->hk);
 	PTHREAD_MUTEX_unlock(&t->mtx);
 

--- a/src/config_samples/config.txt
+++ b/src/config_samples/config.txt
@@ -91,7 +91,7 @@ NFS_CORE_PARAM {}
 
 	DRC_TCP_Cachesz(uint32, range 1 to 255, default 127)
 
-	DRC_TCP_Hiwat(uint32, range 1 to 256, default 64)
+	DRC_TCP_Hiwat(uint32, range 1 to 32767, default 512)
 
 	DRC_TCP_Recycle_Npart(uint32, range 1 to 20, default 7)
 

--- a/src/doc/man/ganesha-core-config.rst
+++ b/src/doc/man/ganesha-core-config.rst
@@ -244,7 +244,7 @@ DRC_TCP_Cachesz(uint32, range 1 to 255, default 127)
     Number of entries in the O(1) front-end cache to a TCP Duplicate Request
     Cache.
 
-DRC_TCP_Hiwat(uint32, range 1 to 256, default 64)
+DRC_TCP_Hiwat(uint32, range 1 to 32767, default 512)
     High water mark for a TCP connection's DRC at which to start retiring
     entries if we can.
 

--- a/src/include/gsh_config.h
+++ b/src/include/gsh_config.h
@@ -116,7 +116,7 @@ typedef enum protos {
 /**
  * @brief Default value for core_param.drc.tcp.hiwat
  */
-#define DRC_TCP_HIWAT 64	/* 1/2(size) */
+#define DRC_TCP_HIWAT 512 /* 1/2(size) */
 
 /**
  * @brief Default value for core_param.drc.tcp.recycle_npart

--- a/src/include/nfs_dupreq.h
+++ b/src/include/nfs_dupreq.h
@@ -53,7 +53,15 @@ enum drc_type {
 typedef struct drc {
 	enum drc_type type;
 	struct rbtree_x xt;
-	/* Define the tail queue */
+	/* Define the tail queue, which contains only completed entries.
+	 *
+	 * Compelted entries are retired in the FIFO order. Inflight
+	 * entries keep in the table and are not retired so that retried
+	 * requests can be suspended by DRC layer and make sure that
+	 * only one of the same retried requests is dispatched into
+	 * the protocol layer and FSAL layer at the same time. Otherwise,
+	 * non-idempotence issues can easily occur.
+	 */
 	TAILQ_HEAD(drc_tailq, dupreq_entry) dupreq_q;
 	pthread_mutex_t drc_mtx;
 	uint32_t npart;

--- a/src/support/nfs_read_conf.c
+++ b/src/support/nfs_read_conf.c
@@ -205,7 +205,7 @@ static struct config_item core_params[] = {
 		       nfs_core_param, drc.tcp.size),
 	CONF_ITEM_UI32("DRC_TCP_Cachesz", 1, 255, DRC_TCP_CACHESZ,
 		       nfs_core_param, drc.tcp.cachesz),
-	CONF_ITEM_UI32("DRC_TCP_Hiwat", 1, 256, DRC_TCP_HIWAT,
+	CONF_ITEM_UI32("DRC_TCP_Hiwat", 1, 32767, DRC_TCP_HIWAT,
 		       nfs_core_param, drc.tcp.hiwat),
 	CONF_ITEM_UI32("DRC_TCP_Recycle_Npart", 1, 20, DRC_TCP_RECYCLE_NPART,
 		       nfs_core_param, drc.tcp.recycle_npart),


### PR DESCRIPTION
Currently, entries in the fifo queue can be retired no matter whether they are inflight or completed. If the inflight entry is retired and then the retry request comes in, another DRC entry will be allocated to this request and it will be also dispatched and processed, at the same time with the first one. The same two inflight requests may lead to data inconsistenty including the "lost write due to duplicated truncate" issue.

Considering the following case:
1. The application wants to truncate a existent file and write it. It opens the file and sends SETATTR request.
2. FSAL is not available to handle SETATTR and hangs there.
3. There are many other requests processed successfully and the first SETATTR DRC entry is retired.
4. Timeout arrives and NFS client retry SETATTR request.
5. The second SETATTR is dispatched into FSAL and also hangs.
6. The first SETATTR completes successfully and send reply to NFS client.
7. NFS client sends WRITE requests.
8. WRITE completes successfully.
9. The second SETATTR finishes and reset the WRITE in step 8, which means the write is lost.

This commit only retires completed entries and always keep the inflight entry in DRC to suspend retried requests. In the above example, the inflight SETATTR entry is NOT retired in step 3, and the second SETATTR will be suspend in step 5, and it will be ignored in step 6. So the write will not be lost.

See more:
https://github.com/nfs-ganesha/nfs-ganesha/issues/1253

This commit also brings other changes:
1. set dupreq_entry_t.rc on nfs_dupreq_finish
2. acquire partition lock firstly on delete()
3. set default DRC_TCP_Hiwat to half of DRC_TCP_Size
4. update some comments

Change-Id: I721ef5ff934362ae63624709041a19b268581173




<!--
  - STOP

  - The NFS-Ganesha Project uses gerrithub to review patch submissions

  - See src/CONTRIBUTING_HOWTO.txt or [DevPolicy](https://github.com/nfs-ganesha/nfs-ganesha/wiki/DevPolicy)

  - In a nutshell, here's how to submit a patch for NFS-Ganesha to gerrithub

```
$ git clone ssh://USERNAMEHERE@review.gerrithub.io:29418/ffilz/nfs-ganesha
 $ cd nfs-ganesha
 nfs-ganesha$ git remote add gerrit ssh://USERNAMEHERE@review.gerrithub.io:29418/ffilz/nfs-ganesha
 nfs-ganesha$ git fetch gerrit
 nfs-ganesha$ ./src/scripts/git_hooks/install_git_hooks.sh
 nfs-ganesha$ git log gerrit/next..HEAD
 # this should ONLY list the commits you want to push!
 nfs-ganesha$ git push gerrit HEAD:refs/for/next
```

  - Look for your patch at [GerritHub](https://review.gerrithub.io/dashboard/self)

-->
