### PR TITLE
[pick from 1.2.0-hp] fix(nfs3_setattr): fix null pointer dereference in WCC handling

### DIFF
--- a/src/Protocols/NFS/nfs3_setattr.c
+++ b/src/Protocols/NFS/nfs3_setattr.c
@@ -164,25 +164,19 @@ int nfs3_setattr(nfs_arg_t *arg, struct svc_req *req, nfs_res_t *res)
 				nfs3_Errno_status(fsal_status);
 			LogFullDebug(COMPONENT_NFSPROTO,
 				     "fsal_setattr failed");
-			if (nfs_RetryableError(fsal_status.major)) {
-				/* Drop retryable request. */
-				rc = NFS_REQ_DROP;
-			}
-			goto out;
+			goto out_fail;
 		}
 	}
 
 	/* Set the NFS return */
 	res->res_setattr3.status = NFS3_OK;
 
+	/* Build Weak Cache Coherency data */
+	nfs_SetWccData(&pre_attr, obj, &resok->obj_wcc);
+
 	rc = NFS_REQ_OK;
 
  out:
-
-	if (rc != NFS_REQ_DROP) {
-		/* Build Weak Cache Coherency data */
-		nfs_SetWccData(&pre_attr, obj, NULL, &resok->obj_wcc);
-	}
 
 	/* Release the attributes (may release an inherited ACL) */
 	fsal_release_attrs(&setattr);
@@ -197,6 +191,17 @@ int nfs3_setattr(nfs_arg_t *arg, struct svc_req *req, nfs_res_t *res)
 		 rc == NFS_REQ_DROP ? " Dropping response" : "");
 
 	return rc;
+
+ out_fail:
+
+	if (nfs_RetryableError(fsal_status.major)) {
+		/* Drop retryable request. */
+		rc = NFS_REQ_DROP;
+	} else {
+		nfs_SetWccData(&pre_attr, obj, &resfail->obj_wcc);
+	}
+
+	goto out;
 }				/* nfs3_setattr */
 
 /**


### PR DESCRIPTION
If nfs3_FhandleToCache() fails, the object is null, which is used in nfs_SetWccData(). This commit fixes this bug.

Change-Id: Ie9261ef51584dc06434a214a0423ad60aa7b05f9




<!--
  - STOP

  - The NFS-Ganesha Project uses gerrithub to review patch submissions

  - See src/CONTRIBUTING_HOWTO.txt or [DevPolicy](https://github.com/nfs-ganesha/nfs-ganesha/wiki/DevPolicy)

  - In a nutshell, here's how to submit a patch for NFS-Ganesha to gerrithub

```
$ git clone ssh://USERNAMEHERE@review.gerrithub.io:29418/ffilz/nfs-ganesha
 $ cd nfs-ganesha
 nfs-ganesha$ git remote add gerrit ssh://USERNAMEHERE@review.gerrithub.io:29418/ffilz/nfs-ganesha
 nfs-ganesha$ git fetch gerrit
 nfs-ganesha$ ./src/scripts/git_hooks/install_git_hooks.sh
 nfs-ganesha$ git log gerrit/next..HEAD
 # this should ONLY list the commits you want to push!
 nfs-ganesha$ git push gerrit HEAD:refs/for/next
```

  - Look for your patch at [GerritHub](https://review.gerrithub.io/dashboard/self)

-->
