### PR TITLE
feat(heartbeat): add Hung status to detect unresponsive ganesha

### DIFF
--- a/src/MainNFSD/nfs_init.c
+++ b/src/MainNFSD/nfs_init.c
@@ -1113,25 +1113,28 @@ int nfs_init_wait_timeout(int timeout)
 bool nfs_health(void)
 {
 	uint64_t newenq, newdeq;
-	uint64_t dequeue_diff, enqueue_diff;
-	bool healthy;
+	uint64_t dequeue_diff;
+	bool high_inflight;
+	bool hung;
 
-	newenq = nfs_health_.enqueued_reqs;
 	newdeq = nfs_health_.dequeued_reqs;
-	enqueue_diff = newenq - healthstats.enqueued_reqs;
+	newenq = nfs_health_.enqueued_reqs;
 	dequeue_diff = newdeq - healthstats.dequeued_reqs;
 
-	/* Consider healthy and making progress if we have dequeued some
-	 * requests or there is one or less to dequeue.  Don't check
-	 * enqueue_diff == 0 here, as there will be spurious warnings during
-	 * times of low traffic, when an enqueue happens to coincide with the
-	 * heartbeat firing.
+	/* Consider it is hung if we have NOT dequeued any
+	 * requests even though there are many inflight requests
+	 *
+	 * There are default maximum 200 threads to handle nfs requests,
+	 * so if we have more than 128 requests inflight, it is likely
+	 * that the server is hung.
 	 */
-	healthy = dequeue_diff > 0 || enqueue_diff <= 1;
+	high_inflight = healthstats.dequeued_reqs + 128
+					< healthstats.enqueued_reqs;
+	hung = (dequeue_diff == 0 && high_inflight);
 
-	if (!healthy) {
-		LogWarn(COMPONENT_DBUS,
-			"Health status is unhealthy. "
+	if (hung) {
+		LogWarn(COMPONENT_DISPATCH,
+			"Health status is hung. "
 			"enq new: %" PRIu64 ", old: %" PRIu64 "; "
 			"deq new: %" PRIu64 ", old: %" PRIu64,
 			newenq, healthstats.enqueued_reqs,
@@ -1141,5 +1144,5 @@ bool nfs_health(void)
 	healthstats.enqueued_reqs = newenq;
 	healthstats.dequeued_reqs = newdeq;
 
-	return healthy;
+	return !hung;
 }

--- a/src/SAL/recovery/recovery_sfs_cluster.c
+++ b/src/SAL/recovery/recovery_sfs_cluster.c
@@ -179,8 +179,13 @@ static char *sfs_cluster_create_val(nfs_client_id_t *clientid, size_t *size)
 }
 
 static int get_ganesha_status() {
-	// 0 denotes Initializing; 1 denotes Running.
-	return check_nfs_init_complete();
+	if (!check_nfs_init_complete()) {
+		return 0; // Initializing
+	} else if (nfs_health()) {
+		return 1; // Running
+	} else {
+		return 2; // Hung
+	}
 }
 
 static int sfs_start_grace(const char *vip, int event) {

--- a/src/include/nfs_core.h
+++ b/src/include/nfs_core.h
@@ -102,6 +102,7 @@ struct _nfs_health {
 };
 
 extern struct _nfs_health nfs_health_;
+// False if nfs server is hung, true if healthy
 bool nfs_health(void);
 
 /* ServerEpoch is ServerBootTime unless overridden by -E command line option */


### PR DESCRIPTION
This allows sfs-agent to detect when ganesha becomes unresponsive for an extended period and trigger a restart accordingly.

Change-Id: Ie48af28021343656de92a581cbffba754333d861




<!--
  - STOP

  - The NFS-Ganesha Project uses gerrithub to review patch submissions

  - See src/CONTRIBUTING_HOWTO.txt or [DevPolicy](https://github.com/nfs-ganesha/nfs-ganesha/wiki/DevPolicy)

  - In a nutshell, here's how to submit a patch for NFS-Ganesha to gerrithub

```
$ git clone ssh://USERNAMEHERE@review.gerrithub.io:29418/ffilz/nfs-ganesha
 $ cd nfs-ganesha
 nfs-ganesha$ git remote add gerrit ssh://USERNAMEHERE@review.gerrithub.io:29418/ffilz/nfs-ganesha
 nfs-ganesha$ git fetch gerrit
 nfs-ganesha$ ./src/scripts/git_hooks/install_git_hooks.sh
 nfs-ganesha$ git log gerrit/next..HEAD
 # this should ONLY list the commits you want to push!
 nfs-ganesha$ git push gerrit HEAD:refs/for/next
```

  - Look for your patch at [GerritHub](https://review.gerrithub.io/dashboard/self)

-->
