### PR TITLE
feat(build): disable NFSACL

### DIFF
--- a/src/cmake/build_configurations/sfs_only.cmake
+++ b/src/cmake/build_configurations/sfs_only.cmake
@@ -28,5 +28,7 @@ set(ENABLE_SFS ON)
 
 set(USE_RQUOTA OFF)
 set(USE_NLM OFF)
+set(USE_NFSACL3 OFF)
+set(ENABLE_VFS_POSIX_ACL OFF)
 
 message(STATUS "Building sfs_only configuration")

--- a/src/cmake/build_configurations/vfs_only.cmake
+++ b/src/cmake/build_configurations/vfs_only.cmake
@@ -26,4 +26,9 @@ set(_MSPAC_SUPPORT OFF)
 set(USE_9P OFF)
 set(USE_DBUS OFF)
 
+set(USE_NLM OFF)
+set(USE_RQUOTA OFF)
+set(USE_NFSACL3 OFF)
+set(ENABLE_VFS_POSIX_ACL OFF)
+
 message(STATUS "Building vfs_only configuration")

--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -39,9 +39,14 @@ endif(DARWIN)
 
 if(LINUX)
   SET(gos_STAT_SRCS
-      linux/acl.c
       linux/subr.c
   )
+  if(ENABLE_VFS_POSIX_ACL)
+    set(gos_STAT_SRCS
+      ${gos_STAT_SRCS}
+      linux/acl.c
+    )
+  endif(ENABLE_VFS_POSIX_ACL)
 endif(LINUX)
 
 add_library(gos OBJECT ${gos_STAT_SRCS})


### PR DESCRIPTION
getacl() returns OK without any acl data, which will lead to linux `ls -l` calling getacl() for each sub directory, obviously degrading the performance of `ls -l`.

This commit disables NFSACL and linux `ls -l` is expected to not send getacl() for each directory anymore.

Change-Id: I1039de2711b52643ac5c9a1d4a90d91f2eafe3cf




<!--
  - STOP

  - The NFS-Ganesha Project uses gerrithub to review patch submissions

  - See src/CONTRIBUTING_HOWTO.txt or [DevPolicy](https://github.com/nfs-ganesha/nfs-ganesha/wiki/DevPolicy)

  - In a nutshell, here's how to submit a patch for NFS-Ganesha to gerrithub

```
$ git clone ssh://USERNAMEHERE@review.gerrithub.io:29418/ffilz/nfs-ganesha
 $ cd nfs-ganesha
 nfs-ganesha$ git remote add gerrit ssh://USERNAMEHERE@review.gerrithub.io:29418/ffilz/nfs-ganesha
 nfs-ganesha$ git fetch gerrit
 nfs-ganesha$ ./src/scripts/git_hooks/install_git_hooks.sh
 nfs-ganesha$ git log gerrit/next..HEAD
 # this should ONLY list the commits you want to push!
 nfs-ganesha$ git push gerrit HEAD:refs/for/next
```

  - Look for your patch at [GerritHub](https://review.gerrithub.io/dashboard/self)

-->
