### PR TITLE
refactor(mdcache): Check readdir callback handle and cache if valid

### DIFF
--- a/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_handle.c
+++ b/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_handle.c
@@ -582,10 +582,6 @@ static fsal_status_t mdcache_readdir(struct fsal_obj_handle *dir_hdl,
 		return fsalstat(ERR_FSAL_NOTDIR, 0);
 
 	if (mdcache_param.dir.avl_chunk == 0) {
-		if (attrmask == 0) {
-			return mdcache_readdir_uncached_light(directory, whence, sz, dir_state,
-							cb, attrmask, eod_met);
-		}
 		/* Not caching dirents; pass through directly to FSAL */
 		return mdcache_readdir_uncached(directory, whence, sz, dir_state,
 						cb, attrmask, eod_met);

--- a/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_helpers.c
+++ b/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_helpers.c
@@ -1698,6 +1698,13 @@ mdc_readdir_uncached_cb(const char *name, struct fsal_obj_handle *sub_handle,
 	mdcache_entry_t *new_entry = NULL;
 	enum fsal_dir_result rv;
 
+	if (glist_null(&sub_handle->handles)){
+		/* Call up the stack.  Do a supercall */
+		supercall_raw(state->export,
+				rv = state->cb(name, sub_handle, attrs, state->dir_state, cookie));
+		return rv;
+	}
+
 	/* This is in the middle of a subcall. Do a supercall */
 	supercall_raw(state->export,
 		status = mdcache_new_entry(state->export, sub_handle, attrs,
@@ -1766,48 +1773,6 @@ mdcache_readdir_uncached(mdcache_entry_t *directory, fsal_cookie_t *whence, size
 		readdir_status = directory->sub_handle->obj_ops->readdir(
 			directory->sub_handle, whence, sz, &state,
 			mdc_readdir_uncached_cb, attrmask, eod_met)
-	       );
-
-	if (FSAL_IS_ERROR(readdir_status))
-		return readdir_status;
-
-	return status;
-}
-
-static enum fsal_dir_result
-mdc_readdir_uncached_light_cb(const char *name, struct fsal_obj_handle *sub_handle,
-			struct fsal_attrlist *attrs, void *dir_state,
-			fsal_cookie_t cookie)
-{
-	struct mdcache_populate_cb_state *state = dir_state;
-	enum fsal_dir_result rv;
-
-	/* Call up the stack.  Do a supercall */
-	supercall_raw(state->export,
-			rv = state->cb(name, sub_handle, attrs, state->dir_state, cookie));
-
-	return rv;
-}
-
-fsal_status_t
-mdcache_readdir_uncached_light(mdcache_entry_t *directory, fsal_cookie_t *whence, size_t sz,
-			 void *dir_state, fsal_readdir_cb cb,
-			 attrmask_t attrmask, bool *eod_met)
-{
-	fsal_status_t status = {0, 0};
-	fsal_status_t readdir_status = {0, 0};
-	struct mdcache_populate_cb_state state;
-
-	state.export = mdc_cur_export();
-	state.dir = directory;
-	state.status = &status;
-	state.cb = cb;
-	state.dir_state = dir_state;
-
-	subcall(
-		readdir_status = directory->sub_handle->obj_ops->readdir(
-			directory->sub_handle, whence, sz, &state,
-			mdc_readdir_uncached_light_cb, attrmask, eod_met)
 	       );
 
 	if (FSAL_IS_ERROR(readdir_status))

--- a/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_int.h
+++ b/src/FSAL/Stackable_FSALs/FSAL_MDCACHE/mdcache_int.h
@@ -525,10 +525,6 @@ fsal_status_t mdcache_readdir_uncached(mdcache_entry_t *directory, fsal_cookie_t
 				       *whence, size_t sz, void *dir_state,
 				       fsal_readdir_cb cb, attrmask_t attrmask,
 				       bool *eod_met);
-fsal_status_t mdcache_readdir_uncached_light(mdcache_entry_t *directory, fsal_cookie_t
-				       *whence, size_t sz, void *dir_state,
-				       fsal_readdir_cb cb, attrmask_t attrmask,
-				       bool *eod_met);
 void mdcache_clean_dirent_chunk(struct dir_chunk *chunk);
 void place_new_dirent(mdcache_entry_t *parent_dir,
 		      mdcache_dir_entry_t *new_dir_entry);


### PR DESCRIPTION
mdcache layer checks the validity of the handle returned by the readdir callback and adds it to the cache if it's valid.

