### PR TITLE
feat: add export-level DropDelayErrors config

### DIFF
--- a/src/Protocols/NFS/nfs_proto_tools.c
+++ b/src/Protocols/NFS/nfs_proto_tools.c
@@ -221,7 +221,7 @@ bool nfs_RetryableError(fsal_errors_t fsal_errors)
 		break;
 
 	case ERR_FSAL_DELAY:
-		if (nfs_param.core_param.drop_delay_errors) {
+		if (nfs_DropDelayErrors()) {
 			/* Drop the request */
 			return true;
 		} else {

--- a/src/config_samples/export.txt
+++ b/src/config_samples/export.txt
@@ -127,6 +127,9 @@ EXPORT_DEFAULTS
 #			These 5 options have the same range of values from
 #			512 to 9 megabytes.
 #
+# DropDelayErrors (default unused) Drop rather than reply to NFSv3 delay errors.
+#			When unused, uses NFS_CORE_PARAM Drop_Delay_Errors.
+#
 # MaxOffsetWrite (18446744073709551615)	Maximum file offset that may be written
 # MaxOffsetRead (18446744073709551615)	Maximum file offset that may be read
 #					These options may be used to restrict

--- a/src/doc/man/ganesha-export-config.rst
+++ b/src/doc/man/ganesha-export-config.rst
@@ -222,6 +222,11 @@ PrefWrite (64*1024*1024)
    write size. If so, please try to decrease this size (usually less
    than 1M is suitable for older nfs client).
 
+DropDelayErrors (default unused)
+    For NFSv3, whether to drop rather than reply to requests yielding
+    delay errors. If unused, the NFS_CORE_PARAM Drop_Delay_Errors setting
+    is used. This option is dynamically updateable.
+
 PrefReaddir (16384)
    The preferred readdir size on this export
 

--- a/src/include/nfs_exports.h
+++ b/src/include/nfs_exports.h
@@ -92,6 +92,7 @@ struct exportlist_client_entry {
 						  specified */
 #define EXPORT_OPTION_SECLABEL_SET 0x00000100 /* Set if export supports v4.2
 						 security labels */
+#define EXPORT_OPTION_DROP_DELAY_ERRORS 0x00000200 /* Drop NFSv3 delay errors */
 
 /* Constants for export permissions masks */
 #define EXPORT_OPTION_ROOT 0	/*< Allow root access as root uid */

--- a/src/include/nfs_proto_tools.h
+++ b/src/include/nfs_proto_tools.h
@@ -44,6 +44,7 @@
 #include "nfs_file_handle.h"
 #include "sal_data.h"
 #include "fsal.h"
+#include "nfs_exports.h"
 #ifdef USE_NFSACL3
 #include "posix_acls.h"
 #include <sys/acl.h>
@@ -250,7 +251,13 @@ void nfs_PreOpAttrFromFsalAttr(struct fsal_attrlist *fsal_attrs,
 
 static inline bool nfs_DropDelayErrors(void)
 {
-	return nfs_param.core_param.drop_delay_errors;
+	if (op_ctx == NULL || op_ctx->ctx_export == NULL)
+		return nfs_param.core_param.drop_delay_errors;
+
+	if (!op_ctx_export_has_option_set(EXPORT_OPTION_DROP_DELAY_ERRORS))
+		return nfs_param.core_param.drop_delay_errors;
+
+	return op_ctx_export_has_option(EXPORT_OPTION_DROP_DELAY_ERRORS);
 }
 
 bool nfs_RetryableError(fsal_errors_t fsal_errors);

--- a/src/support/exports.c
+++ b/src/support/exports.c
@@ -2050,6 +2050,9 @@ static struct config_item fsal_params[] = {
 			EXPORT_OPTION_PREFWRITE_SET, options_set),	\
 	CONF_ITEM_UI64("PrefReaddir", 512, FSAL_MAXIOSIZE, 16384,	\
 		       _struct_, PrefReaddir),				\
+	CONF_ITEM_BOOLBIT_SET("DropDelayErrors", false,		\
+		EXPORT_OPTION_DROP_DELAY_ERRORS,			\
+		_struct_, options, options_set),			\
 	CONF_ITEM_FSID_SET("Filesystem_id", 666, 666,			\
 		       _struct_, filesystem_id, /* major.minor */	\
 		       EXPORT_OPTION_FSID_SET, options_set),		\


### PR DESCRIPTION
Allow NFSv3 delay error dropping to be configured per export while preserving the global default when the option is unused.

Example export configuration:

EXPORT {
    Export_Id = 1;
    Path = /export;
    Pseudo = /export;
    DropDelayErrors = true;
}




