### PR TITLE
feat: force NFSv3 sync write when DropDelayErrors is set

### DIFF
--- a/src/Protocols/NFS/nfs3_write.c
+++ b/src/Protocols/NFS/nfs3_write.c
@@ -240,7 +240,16 @@ int nfs3_write(nfs_arg_t *arg, struct svc_req *req, nfs_res_t *res)
 		atomic_fetch_uint64_t(&op_ctx->ctx_export->MaxWrite);
 	uint64_t MaxOffsetWrite =
 		atomic_fetch_uint64_t(&op_ctx->ctx_export->MaxOffsetWrite);
-	bool force_sync = op_ctx->export_perms.options & EXPORT_OPTION_COMMIT;
+	/*
+	 * DropDelayErrors also forces NFSv3 UNSTABLE WRITE to sync. This
+	 * works around a Windows NFS client bug: for Direct I/O, Windows
+	 * may split a large write into multiple asynchronous (UNSTABLE)
+	 * WRITE RPCs; if the backend restarts between them, COMMIT's
+	 * verifier may not cover write1, and Windows does not retry that
+	 * write1 when the COMMIT verifier is inconsistent with it.
+	 */
+	bool force_sync = (op_ctx->export_perms.options &
+			   EXPORT_OPTION_COMMIT) || nfs_DropDelayErrors();
 	WRITE3resfail *resfail = &res->res_write3.WRITE3res_u.resfail;
 	WRITE3resok *resok = &res->res_write3.WRITE3res_u.resok;
 	struct nfs3_write_data *write_data = NULL;

--- a/src/config_samples/export.txt
+++ b/src/config_samples/export.txt
@@ -129,6 +129,7 @@ EXPORT_DEFAULTS
 #
 # DropDelayErrors (default unused) Drop rather than reply to NFSv3 delay errors.
 #			When unused, uses NFS_CORE_PARAM Drop_Delay_Errors.
+#			When effective, also treat NFSv3 UNSTABLE WRITE as sync.
 #
 # MaxOffsetWrite (18446744073709551615)	Maximum file offset that may be written
 # MaxOffsetRead (18446744073709551615)	Maximum file offset that may be read

--- a/src/doc/man/ganesha-export-config.rst
+++ b/src/doc/man/ganesha-export-config.rst
@@ -225,7 +225,9 @@ PrefWrite (64*1024*1024)
 DropDelayErrors (default unused)
     For NFSv3, whether to drop rather than reply to requests yielding
     delay errors. If unused, the NFS_CORE_PARAM Drop_Delay_Errors setting
-    is used. This option is dynamically updateable.
+    is used. When effective, NFSv3 UNSTABLE WRITE requests are also
+    treated as synchronous (FILE_SYNC) writes. This option is
+    dynamically updateable.
 
 PrefReaddir (16384)
    The preferred readdir size on this export


### PR DESCRIPTION
Reuse DropDelayErrors so UNSTABLE WRITE is treated as synchronous. This works around a Windows NFS client bug: for Direct I/O, Windows may split a large write into multiple asynchronous (UNSTABLE) WRITE RPCs. If write1 succeeds, the backend restarts, then write2 and COMMIT succeed, the COMMIT verifier cannot represent write1's durability. The bug is that Windows does not retry write1 when that COMMIT verifier is inconsistent with write1 — forcing sync WRITE avoids that hole.




<!--
  - STOP

  - The NFS-Ganesha Project uses gerrithub to review patch submissions

  - See src/CONTRIBUTING_HOWTO.txt or [DevPolicy](https://github.com/nfs-ganesha/nfs-ganesha/wiki/DevPolicy)

  - In a nutshell, here's how to submit a patch for NFS-Ganesha to gerrithub

```
$ git clone ssh://USERNAMEHERE@review.gerrithub.io:29418/ffilz/nfs-ganesha
 $ cd nfs-ganesha
 nfs-ganesha$ git remote add gerrit ssh://USERNAMEHERE@review.gerrithub.io:29418/ffilz/nfs-ganesha
 nfs-ganesha$ git fetch gerrit
 nfs-ganesha$ ./src/scripts/git_hooks/install_git_hooks.sh
 nfs-ganesha$ git log gerrit/next..HEAD
 # this should ONLY list the commits you want to push!
 nfs-ganesha$ git push gerrit HEAD:refs/for/next
```

  - Look for your patch at [GerritHub](https://review.gerrithub.io/dashboard/self)

-->
